### PR TITLE
Update user guide link

### DIFF
--- a/client/src/components/climatePrediction/Graph.jsx
+++ b/client/src/components/climatePrediction/Graph.jsx
@@ -13,7 +13,7 @@ Common Good Public License Beta 1.0 for more details. */
 import "../../../node_modules/react-vis/dist/style.css";
 import "./Graph.css";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useCollapse } from "react-collapsed";
 import LoadingOverlay from "react-loading-overlay-ts";
 import { ChartLabel, LabelSeries, makeWidthFlexible, VerticalBarSeries, XAxis, XYPlot, YAxis } from "react-vis";
@@ -263,11 +263,11 @@ const Graph = (props) => {
                 CHESS-SCAPE provides non bias-corrected data for Northern Ireland and the Isles of Scilly. The tool
                 displays RCP 6.0 and RCP 8.5. For more information, please see the{" "}
                 <a
-                    href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE_FINAL-Autumn-24.pdf"
+                    href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE-June-2025-update.pdf"
                     target="_blank"
                     rel="noreferrer"
                 >
-                    LCAT User Guide.
+                    LCAT Handbook.
                 </a>
             </p>
         </div>

--- a/client/src/components/footer/Footer.css
+++ b/client/src/components/footer/Footer.css
@@ -51,7 +51,7 @@
     background-size: 100% 100%;
 }
 
-.user-guide-button {
+.handbook-button {
     display: inline-block;
     width: 50px;
     height: 50px;
@@ -62,7 +62,7 @@
     margin-left: 1em;
 }
 
-.user-guide-button:hover {
+.handbook-button:hover {
     background: url("../../images/buttons/faq_button_selected_yellow.png") no-repeat;
     background-size: 100% 100%;
 }

--- a/client/src/components/footer/Footer.jsx
+++ b/client/src/components/footer/Footer.jsx
@@ -16,14 +16,14 @@ import AdaptationGuide from "./AdaptationGuide";
 import ContactUs from "./ContactUs";
 import FooterLogos from "./FooterLogos";
 import FooterText from "./FooterText";
-import UserGuide from "./UserGuide";
+import Handbook from "./Handbook";
 
 const Footer = () => {
     return (
         <div>
             <div className="contact-footer">
                 <ContactUs />
-                <UserGuide />
+                <Handbook />
                 <AdaptationGuide />
             </div>
             <FooterLogos />

--- a/client/src/components/footer/Handbook.jsx
+++ b/client/src/components/footer/Handbook.jsx
@@ -10,30 +10,29 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 Common Good Public License Beta 1.0 for more details. */
 
-import React from "react";
 
-const UserGuide = () => {
+const Handbook = () => {
     return (
         <div className="footer-flex-container">
-            <div className="footer-heading">Access our User Guide.</div>
+            <div className="footer-heading">Access our Handbook.</div>
             <div className="footer-flex-content">
                 <p>
                     <a
-                        className="user-guide-button"
-                        href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE_FINAL-Autumn-24.pdf"
+                        className="handbook-button"
+                        href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE-June-2025-update.pdf"
                         target="_blank"
                         rel="noreferrer"
-                        aria-label="Read the LCAT User Guide PDF"
+                        aria-label="Read the LCAT Handbook PDF"
                     ></a>
                 </p>
                 <p>
                     Read the&nbsp;
                     <a
-                        href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE_FINAL-Autumn-24.pdf"
+                        href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE-June-2025-update.pdf"
                         target="_blank"
                         rel="noreferrer"
                     >
-                        LCAT User Guide (at ecehh.org)
+                        LCAT Handbook (at ecehh.org)
                     </a>
                 </p>
             </div>
@@ -41,4 +40,4 @@ const UserGuide = () => {
     );
 };
 
-export default UserGuide;
+export default Handbook;

--- a/client/src/components/header/Introduction.jsx
+++ b/client/src/components/header/Introduction.jsx
@@ -49,11 +49,11 @@ const Introduction = () => {
                 </li>
                 <li>
                     <a
-                        href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE_FINAL-Autumn-24.pdf"
+                        href="https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE-June-2025-update.pdf"
                         target="_blank"
                         rel="noreferrer"
                     >
-                        LCAT User Guide
+                        LCAT Handbook
                     </a>
                 </li>
                 <li>

--- a/data/src/coastal_identifier.py
+++ b/data/src/coastal_identifier.py
@@ -73,6 +73,7 @@ class CoastalIdentifier:
                     SET is_coastal = TRUE;
                 """
                 self.cur.execute(update_query)
+                self.conn.commit()
 
             else:
                 # Make coastal values a tuple
@@ -89,8 +90,8 @@ class CoastalIdentifier:
                     );
                 """
                 self.cur.execute(update_query, (coastal_values,))
+                self.conn.commit()
 
-            self.conn.commit()
             print(f"Boundary {boundary_identifier} processed successfully.")
 
         except psycopg2.Error as e:


### PR DESCRIPTION
Update link from [autumn 24](https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE_FINAL-Autumn-24.pdf) to [June 25](https://www.ecehh.org/wp/wp-content/uploads/2021/09/LCAT-USER-GUIDE-June-2025-update.pdf), and rename from 'User Guide' to 'Handbook'.