### PR TITLE
fix: fix page crashing on region type change

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -56,7 +56,6 @@ const App = () => {
             setVariable(defaultState.variable);
             setClimatePrediction(defaultState.climatePrediction)
             setClimateAverages(defaultState.climateAverages)
-            setClimateAverageRanges(defaultState.climateAverageRanges)
             setSelectedHazardName(defaultState.selectedHazardName)
             setApplyCoastalFilter(defaultState.applyCoastalFilter)
         }
@@ -87,7 +86,6 @@ const App = () => {
             />
 
              <ClimateAverageRangesLoader
-                variable={variable}
                 setClimateAverageRanges={setClimateAverageRanges}
             />
 

--- a/client/src/components/climatePrediction/Graph.jsx
+++ b/client/src/components/climatePrediction/Graph.jsx
@@ -61,7 +61,6 @@ const Graph = (props) => {
 
     useEffect(() => {
         if (climatePrediction.length === 0 || !climatePrediction[0][`${variable}_1980_mean`]) return;
-        console.log(climateAverageRanges)
         const years = [1980, 2030, 2040, 2050, 2060, 2070];
 
         const data = years.map((year) => ({
@@ -79,7 +78,7 @@ const Graph = (props) => {
         setData(data);
         setAvgMin(avMin);
         setAvgMax(avMax);
-    }, [climatePrediction, rcp, season, showAverage, variable, climateAverages]);
+    }, [climatePrediction, rcp, season, showAverage, variable, climateAverages, climateAverageRanges]);
 
     useEffect(() => {
         if (regions.length === 0) {
@@ -263,7 +262,7 @@ const Graph = (props) => {
 
 
   // Pad by 5% either side
-  const variableRange = climateAverageRanges[variable];
+  const variableRange = climateAverageRanges && climateAverageRanges[variable];
     const paddedRange = variableRange
         ? [
             variableRange[0] - 0.05 * (variableRange[1] - variableRange[0]),

--- a/client/src/components/loaders/ClimateAverageRangesLoader.jsx
+++ b/client/src/components/loaders/ClimateAverageRangesLoader.jsx
@@ -10,7 +10,7 @@ Common Good Public License Beta 1.0 for more details. */
 
 import { useEffect } from "react";
 
-const ClimateAverageRangesLoader = ({ variable, setClimateAverageRanges }) => {
+const ClimateAverageRangesLoader = ({ setClimateAverageRanges }) => {
     useEffect(() => {
         const fetchClimateAverageRanges = async () => {
             try {
@@ -19,7 +19,6 @@ const ClimateAverageRangesLoader = ({ variable, setClimateAverageRanges }) => {
                 // Construct query params
                 const queryParams = new URLSearchParams({
                     is_bias_corrected: JSON.stringify(true),
-                    variable,
                 });
 
                 const url = `${prepend}/api/chess_scape_uk_variable_ranges?${queryParams}`;
@@ -36,12 +35,12 @@ const ClimateAverageRangesLoader = ({ variable, setClimateAverageRanges }) => {
                 // Store fetched data in state
                 setClimateAverageRanges(data);
             } catch (error) {
-                console.error("Error fetching climate averages:", error);
+                console.error("Error fetching climate average ranges:", error);
             }
         };
 
         fetchClimateAverageRanges();
-    }, [variable, setClimateAverageRanges]);
+    }, [setClimateAverageRanges]);
 
     return null;
 };


### PR DESCRIPTION
FIx for bug from https://github.com/Uni-of-Exeter/research.LCAT.public/pull/36

Changing region type was causing page to crash, as climate average ranges became undefined. 

Added defensive defaults to the graph so it would fail more gracefully (ie not crash), and stopped resetting `climateAverageRanges` in `App.jsx` whenever no regions where selected, so it doesn't become undefined.