### PR TITLE
main-dev branch configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/data"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"

--- a/.github/workflows/restrict-pr-to-main.yml
+++ b/.github/workflows/restrict-pr-to-main.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/restrict-pr-to-main.yml
+++ b/.github/workflows/restrict-pr-to-main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fail if source branch is not dev
-        if: github.head_ref != 'dev'
+        if: github.head_ref != 'dev' || github.event.pull_request.head.repo.full_name != github.repository
         run: |
-          echo "PRs to main must come from dev. Source branch: ${{ github.head_ref }}"
+          echo "PRs to main must come from this repository's dev branch. Source branch: ${{ github.head_ref }}. Source repository: ${{ github.event.pull_request.head.repo.full_name }}"
           exit 1

--- a/.github/workflows/restrict-pr-to-main.yml
+++ b/.github/workflows/restrict-pr-to-main.yml
@@ -1,0 +1,14 @@
+name: Restrict PRs to main
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if source branch is not dev
+        if: github.head_ref != 'dev'
+        run: |
+          echo "PRs to main must come from dev. Source branch: ${{ github.head_ref }}"
+          exit 1


### PR DESCRIPTION
1. Changes dependabot auto PRs to open to `dev` rather than `main`
2. Adds a rule that only `dev` can open PRs to `main` generally